### PR TITLE
Improved the vdelay_full codepath, shrinking it from 22 down to 13 bytes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Authors:
 * Fiskbit ([source](https://forums.nesdev.com/viewtopic.php?p=257651#p257651))
 * [Eric Anderson](https://github.com/ejona86) ([source](http://forums.nesdev.com/viewtopic.php?p=258154#p258154))
 * [Joel Yliluoma](https://bisqwit.iki.fi/) ([source](https://wiki.nesdev.com/w/index.php/Delay_code))
-* [George Foot](https://github.com/gfoot)([issue](https://github.com/bbbradsmith/6502vdelay/issues/6))
-* [Sidney Cadot](https://github.com/sidneycadot)([PR](https://github.com/bbbradsmith/6502vdelay/pull/4))
+* [George Foot](https://github.com/gfoot) ([issue](https://github.com/bbbradsmith/6502vdelay/issues/6))
+* [Sidney Cadot](https://github.com/sidneycadot) ([PR](https://github.com/bbbradsmith/6502vdelay/pull/4))
 
-Version 10
+Version 11
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Authors:
 * Fiskbit ([source](https://forums.nesdev.com/viewtopic.php?p=257651#p257651))
 * [Eric Anderson](https://github.com/ejona86) ([source](http://forums.nesdev.com/viewtopic.php?p=258154#p258154))
 * [Joel Yliluoma](https://bisqwit.iki.fi/) ([source](https://wiki.nesdev.com/w/index.php/Delay_code))
+* [George Foot](https://github.com/gfoot)([issue](https://github.com/bbbradsmith/6502vdelay/issues/6))
+* [Sidney Cadot](https://github.com/sidneycadot)([PR](https://github.com/bbbradsmith/6502vdelay/pull/4))
 
 Version 10
 
@@ -121,6 +123,9 @@ The NES ROM compiled to **test/temp/test_nes.nes** can be used to test the code 
   * vdelay_short - 27, 30.
   * vdelay_short_modify - obsoleted.
   * vdelay_short_extreme - obsoleted.
+* Version 11
+  * vdelay - 29, 46.
+  * vdelay_short - 27, 30 - unchanged.
 
 ## License
 

--- a/vdelay.s
+++ b/vdelay.s
@@ -16,7 +16,7 @@
 ;   A/X clobbered (X=0)
 
 VDELAY_MINIMUM = 29
-VDELAY_FULL_OVERHEAD = 49
+VDELAY_FULL_OVERHEAD = 34
 
 ; assert to make sure branches do not page-cross
 .macro BRPAGE instruction_, label_
@@ -27,9 +27,9 @@ VDELAY_FULL_OVERHEAD = 49
 .align 64
 
 vdelay:                                ; +6 = 6 (jsr)
-    cpx #0                             ; +2 = 8 (sets carry)
+           cpx #0                      ; +2 = 8 (sets carry)
     BRPAGE bne, vdelay_full            ; +2 = 10
-    sbc #VDELAY_MINIMUM+4              ; +2 = 12
+           sbc #VDELAY_MINIMUM+4       ; +2 = 12
     BRPAGE bcc, vdelay_low             ; +2 = 14
 vdelay_full_return:
     ; 5-cycle coundown loop + 5 paths   +19 = 33 (carry is set on entry)
@@ -45,28 +45,19 @@ vdelay_full_return:
 
 ; 29-32 cycles handled separately
 vdelay_low:                            ; +1 = 15 (bcc)
-    adc #3                             ; +2 = 17
+           adc #3                      ; +2 = 17
     BRPAGE bcc, @0  ;  3 2 2 2  <0 00 01 02
     BRPAGE beq, @0  ;  - 3 2 2  -- 00 01 02
            lsr      ;  - - 2 2  -- -- 00 01
 @0: BRPAGE bne, @1  ;  3 2 2 3  <0 00 00 01
-@1: rts                                ; +6 = 29 (end < 33)
+@1:        rts                    ; +6 = 29 (end < 33)
 
-vdelay_full:                           ; +3 = 11 (carry is set)
-    sbc #VDELAY_FULL_OVERHEAD          ; +2 = 13
-    pha                                ; +3 = 16
-    txa                                ; +2 = 18
-    sbc #0                             ; +2 = 20
-    BRPAGE beq, vdelay_high_none       ; +2 = 22
-    : ; 256 cycles each iteration
-        ldx #50            ; +2 = 2
-        : ; 5 cycle loop   +250 = 252
-            dex
-            BRPAGE bne, :- ; -1 = 251
-        sbc #1             ; +2 = 253 (carry always set)
-        BRPAGE bne, :--    ; +3 = 256    -1 = 21 (on last iteration)
-    nop                                ; +2 = 23
-vdelay_high_none:                      ; +3 = 23 (from branch)
-    pla                                ; +4 = 27
-    jmp vdelay_full_return             ; +3 = 30 (carry always set)
-    ;                                -14+33 = 49
+vdelay_full:
+           ; We enter a loop that burns and subtracts 5 or 11 cycles during each traversal.
+           sbc #5                           ; Carry is set, here.
+    BRPAGE bcs, vdelay_full
+           sbc #(6 - 1)                     ; We want to subtract 6, but carry is clear, here.
+           dex
+    BRPAGE bne, vdelay_full
+           sbc  #VDELAY_FULL_OVERHEAD       ; Carry is set, here.
+    BRPAGE bcs, vdelay_full_return          ; Carry is set, here.

--- a/vdelay.s
+++ b/vdelay.s
@@ -1,12 +1,14 @@
 ; vdelay
 ;
 ; Authors:
-; - Eric Anderson
-; - Joel Yliluoma
 ; - Brad Smith
 ; - Fiskbit
+; - Eric Anderson
+; - Joel Yliluoma
+; - George Foot
+; - Sidney Cadot
 ;
-; Version 10
+; Version 11
 ; https://github.com/bbbradsmith/6502vdelay
 
 .export vdelay
@@ -27,12 +29,12 @@ VDELAY_FULL_OVERHEAD = 34
 .align 64
 
 vdelay:                                ; +6 = 6 (jsr)
-           cpx #0                      ; +2 = 8 (sets carry)
+    cpx #0                             ; +2 = 8 (sets carry)
     BRPAGE bne, vdelay_full            ; +2 = 10
-           sbc #VDELAY_MINIMUM+4       ; +2 = 12
+    sbc #VDELAY_MINIMUM+4              ; +2 = 12
     BRPAGE bcc, vdelay_low             ; +2 = 14
 vdelay_full_return:
-    ; 5-cycle coundown loop + 5 paths   +19 = 33 (carry is set on entry)
+    ; 5-cycle countdown loop + 5 paths  +19 = 33 (carry is set on entry)
 @L:        sbc #5
     BRPAGE bcs, @L  ;  6 6 6 6 6  FB FC FD FE FF
            adc #3   ;  2 2 2 2 2  FE FF 00 01 02
@@ -43,21 +45,27 @@ vdelay_full_return:
 @5: BRPAGE bcs, @6  ;  2 3 2 3 3  7F 7F 00 00 00
 @6:        rts      ;  6 6 6 6 6                 (end >= 33)
 
+; 256+ cycles
+vdelay_full:                           ; +3 = 11 (from: bne vdelay_full)
+@C: ; 5-cycle countdown until A underflows (carry is set on entry)
+    sbc #5          ;  2
+    BRPAGE bcs, @C  ;  3 (2 on underflow)
+    ; decrement X before resuming countdown
+    sbc #(6 - 1)    ;  2 (subtracting 6, but carry is clear: adjust by -1)
+    dex             ;  2 (note: carry is now set, A >= $FB before sbc)
+    BRPAGE bne, @C  ;  3 (2 when finished)
+    ; adjust for overhead before returning to the entry routine:
+    ;   bne @C not taken when X is 0     -1 = 10
+    ;   vdelay_full_return sequence     +19 = 29
+    sbc #VDELAY_FULL_OVERHEAD          ; +2 = 31
+    BRPAGE bcs, vdelay_full_return     ; +3 = 34 (end >= 34)
+    ; (note: carry is set, A >= $F5 before sbc)
+
 ; 29-32 cycles handled separately
 vdelay_low:                            ; +1 = 15 (bcc)
-           adc #3                      ; +2 = 17
+    adc #3                             ; +2 = 17
     BRPAGE bcc, @0  ;  3 2 2 2  <0 00 01 02
     BRPAGE beq, @0  ;  - 3 2 2  -- 00 01 02
            lsr      ;  - - 2 2  -- -- 00 01
 @0: BRPAGE bne, @1  ;  3 2 2 3  <0 00 00 01
-@1:        rts                    ; +6 = 29 (end < 33)
-
-vdelay_full:
-           ; We enter a loop that burns and subtracts 5 or 11 cycles during each traversal.
-           sbc #5                           ; Carry is set, here.
-    BRPAGE bcs, vdelay_full
-           sbc #(6 - 1)                     ; We want to subtract 6, but carry is clear, here.
-           dex
-    BRPAGE bne, vdelay_full
-           sbc  #VDELAY_FULL_OVERHEAD       ; Carry is set, here.
-    BRPAGE bcs, vdelay_full_return          ; Carry is set, here.
+@1: rts                                ; +6 = 29 (end < 33)

--- a/vdelay_short.s
+++ b/vdelay_short.s
@@ -1,12 +1,14 @@
 ; vdelay (short version)
 ;
 ; Authors:
-; - Eric Anderson
-; - Joel Yliluoma
 ; - Brad Smith
 ; - Fiskbit
+; - Eric Anderson
+; - Joel Yliluoma
+; - George Foot
+; - Sidney Cadot
 ;
-; Version 10
+; Version 11
 ; https://github.com/bbbradsmith/6502vdelay
 
 .export vdelay


### PR DESCRIPTION
I also changed the layout a bit to make the 6502 mnemonics line up in the code I didn't touch.

Feel free to alter/improve comments to comply with the rest of the code.